### PR TITLE
fix(codegen): prevent discriminator variant merging with original model

### DIFF
--- a/crates/schematools/resources/test/openapi/05-discriminator-merge.yaml
+++ b/crates/schematools/resources/test/openapi/05-discriminator-merge.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Discriminator Merge Test
+components:
+  schemas:
+    kindDiscriminator:
+      oneOf:
+        - $ref: '#/components/schemas/KindDiscriminatorSimple'
+        - $ref: '#/components/schemas/KindDiscriminatorComplex'
+        - $ref: '#/components/schemas/KindDiscriminatorSemi'
+      discriminator:
+        propertyName: testField
+        mapping:
+          simple: '#/components/schemas/KindDiscriminatorSimple'
+          complex: '#/components/schemas/KindDiscriminatorComplex'
+          semi: '#/components/schemas/KindDiscriminatorSemi'
+    KindDiscriminatorSimple:
+      type: object
+      required: ['name', 'testField']
+      additionalProperties: false
+      properties:
+        testField:
+          type: string
+        name:
+          type: string
+    KindDiscriminatorComplex:
+      type: object
+      required: ['name', 'testField']
+      additionalProperties: false
+      properties:
+        testField:
+          type: string
+        name:
+          type: string
+    KindDiscriminatorSemi:
+      type: object
+      required: ['testField']
+      additionalProperties: false
+      properties:
+        testField:
+          type: string
+paths: {}

--- a/crates/schematools/src/codegen/jsonschema/anyoneof/extractor.rs
+++ b/crates/schematools/src/codegen/jsonschema/anyoneof/extractor.rs
@@ -265,6 +265,12 @@ impl Extractor for Discriminator {
                     _ => None,
                 };
 
+                // The schema hash was computed from the original referenced
+                // schema, but the variant has been mutated (discriminator field
+                // removed). Clear it so that --merge-similar-models does not
+                // merge the modified variant back with the original model.
+                m.attributes.schema_hash = None;
+
                 m.flatten(container, scope).map(|mut f| {
                     f.attributes.x.insert(
                         DISCRIMINATOR_META.to_owned(),

--- a/crates/schematools/src/codegen/openapi/mod.rs
+++ b/crates/schematools/src/codegen/openapi/mod.rs
@@ -1496,4 +1496,45 @@ mod tests {
             "NullablePriceType property should keep nullable=true"
         );
     }
+
+    #[test]
+    fn test_discriminator_variants_do_not_require_tag_field_with_merge_similar_models() {
+        let url = Url::parse(&format!(
+            "file://{}/resources/test/openapi/05-discriminator-merge.yaml",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let schema = Schema::load_url(url).unwrap();
+
+        let client = Client::new();
+        let storage = SchemaStorage::new(&schema, &client);
+
+        let openapi = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions {
+                merge_similar_models: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let value = serde_json::to_value(&openapi).unwrap();
+        let models = value["models"]["models"].as_array().unwrap();
+
+        for model in models {
+            if let Some(name) = model["object"]["name"].as_str() {
+                if name.ends_with("Variant") {
+                    for prop in model["object"]["properties"].as_array().unwrap_or(&vec![]) {
+                        assert_ne!(
+                            prop["name"].as_str(),
+                            Some("testField"),
+                            "variant {} should not contain testField",
+                            name
+                        );
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
When --merge-similar-models is enabled, the modified oneOf variant (with the discriminator field removed) was merged back into the original referenced model because both shared the same schema_hash. Clear the schema_hash after mutating the variant so it is treated as a distinct model and the generated internally tagged enum no longer requires the discriminator field on each variant.